### PR TITLE
Bump version to 2.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,7 +4958,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ultralog"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultralog"
-version = "2.7.0"
+version = "2.8.0"
 edition = "2021"
 description = "A high-performance ECU log viewer written in Rust"
 authors = ["Cole Gentry"]


### PR DESCRIPTION
## Summary
- Bumps version from 2.7.0 to 2.8.0 for the MCP server release

## Test plan
- [x] `cargo check` passes