### PR TITLE
ci: optimize GitHub Actions to reduce costs (~$18-20/mo savings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master, dev]
+    branches: [main, dev]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Faster compilation with incremental disabled for CI
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -74,40 +77,17 @@ jobs:
             libx11-xcb-dev \
             libxml2-dev
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-lint-
-
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
         continue-on-error: true
 
   # ============================================
-  # Test - Run on all platforms
+  # Test - Linux only (cross-platform in release)
   # ============================================
   test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Test
+    runs-on: ubuntu-latest
     needs: format
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -118,10 +98,9 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "test-${{ matrix.os }}"
+          shared-key: "test"
 
       - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -142,26 +121,6 @@ jobs:
             libxcb-xkb-dev \
             libx11-xcb-dev \
             libxml2-dev
-
-      - name: Cache vcpkg
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@v4
-        with:
-          path: C:\vcpkg
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-
-
-      - name: Install Windows dependencies (vcpkg)
-        if: matrix.os == 'windows-latest'
-        run: |
-          if (!(Test-Path C:\vcpkg)) {
-            git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
-            C:\vcpkg\bootstrap-vcpkg.bat
-          }
-          C:\vcpkg\vcpkg install libxml2:x64-windows
-          echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
-          echo "C:\vcpkg\installed\x64-windows\bin" >> $env:GITHUB_PATH
 
       - name: Run cargo check
         run: cargo check --all-targets
@@ -171,87 +130,6 @@ jobs:
         env:
           LD_LIBRARY_PATH: /usr/lib/x86_64-linux-gnu:${{ github.workspace }}/target/debug/build
           LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libxml2.so.2
-
-  # ============================================
-  # Build - Verify release builds work
-  # ============================================
-  build:
-    name: Build (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    needs: [lint, test]
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "build-${{ matrix.os }}"
-
-      - name: Install Linux dependencies
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libxcb-render0-dev \
-            libxcb-shape0-dev \
-            libxcb-xfixes0-dev \
-            libxkbcommon-dev \
-            libssl-dev \
-            libgtk-3-dev \
-            libglib2.0-dev \
-            libatk1.0-dev \
-            libcairo2-dev \
-            libpango1.0-dev \
-            libgdk-pixbuf2.0-dev \
-            libwayland-dev \
-            libxcb1-dev \
-            libxcb-randr0-dev \
-            libxcb-xkb-dev \
-            libx11-xcb-dev \
-            libxml2-dev
-
-      - name: Cache vcpkg
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@v4
-        with:
-          path: C:\vcpkg
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('.github/workflows/ci.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-
-
-      - name: Install Windows dependencies (vcpkg)
-        if: matrix.os == 'windows-latest'
-        run: |
-          if (!(Test-Path C:\vcpkg)) {
-            git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
-            C:\vcpkg\bootstrap-vcpkg.bat
-          }
-          C:\vcpkg\vcpkg install libxml2:x64-windows
-          echo "VCPKG_ROOT=C:\vcpkg" >> $env:GITHUB_ENV
-          echo "C:\vcpkg\installed\x64-windows\bin" >> $env:GITHUB_PATH
-
-      - name: Build release binary
-        run: cargo build --release
-
-      - name: Verify binary exists (Unix)
-        if: matrix.os != 'windows-latest'
-        run: |
-          ls -la target/release/ultralog
-          file target/release/ultralog
-
-      - name: Verify binary exists (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          dir target\release\ultralog.exe
 
   # ============================================
   # Documentation - Verify docs build


### PR DESCRIPTION
## Summary
- Removed cross-platform matrix (macOS + Windows) from CI `test` and `build` jobs — these now run on **Ubuntu only**
- Removed the entire `build` job from CI (the `release.yml` workflow already handles cross-platform release builds when you tag)
- Added `concurrency` group with `cancel-in-progress` to prevent piling up redundant runs
- Removed duplicate cargo registry cache entries (Swatinem/rust-cache already handles this)
- Removed push trigger on `master` branch (only `main` is used)

## Why this matters
macOS runners cost **10x** Linux, Windows costs **2x**. Running test+build on all 3 platforms for every push/PR was the #1 cost driver at **$22.14/mo**. The release workflow still builds all platforms when you push a tag.

## What's preserved
- Format check, Clippy lint, tests, and docs all still run on every push/PR
- Cross-platform release builds (macOS Intel, macOS ARM, Windows, Linux) unchanged in `release.yml`
- Rust caching via `Swatinem/rust-cache` still active

## Estimated savings
~$18-20/month (from $22.14 down to ~$2-4)

## Test plan
- [ ] Verify CI passes on this PR (ubuntu-only jobs)
- [ ] Verify `release.yml` still works on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)