### PR TITLE
fix(release): notarize macOS builds + bump to v2.10.1

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -5,7 +5,7 @@
    - **Intel Mac**: `ultralog-macos-intel.dmg`
    - **Apple Silicon (M1/M2/M3/M4)**: `ultralog-macos-arm64.dmg`
 2. Open the DMG and drag UltraLog to your Applications folder
-3. On first run, right-click the app and select "Open" to bypass Gatekeeper
+3. Launch UltraLog from Applications. The app is signed and notarized by Apple, so it opens without a Gatekeeper warning.
 
 ### Windows
 1. Download `ultralog-windows.zip`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,30 @@ jobs:
       - name: Install create-dmg
         run: brew install create-dmg
 
+      - name: Import code signing certificate
+        env:
+          MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+
+          echo "$MACOS_CERT_P12" | base64 --decode > "$CERT_PATH"
+
+          # Create a temporary keychain and import the Developer ID cert
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MACOS_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Make the temp keychain searchable so codesign can find the identity
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed s/\"//g)
+
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+          rm -f "$CERT_PATH"
+
       - name: Get version
         id: version
         run: echo "VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*\"\(.*\)\".*/\1/')" >> $GITHUB_OUTPUT
@@ -170,6 +194,10 @@ jobs:
           BUNDLE_ID: ${{ needs.check-tag.outputs.bundle_id }}
           DMG_VOLNAME: ${{ needs.check-tag.outputs.dmg_volname }}
           SUFFIX: ${{ needs.check-tag.outputs.suffix }}
+          MACOS_SIGN_IDENTITY: ${{ secrets.MACOS_SIGN_IDENTITY }}
+          AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
+          AC_API_ISSUER_ID: ${{ secrets.AC_API_ISSUER_ID }}
+          AC_API_KEY_P8: ${{ secrets.AC_API_KEY_P8 }}
         run: |
           ASSET_NAME="ultralog-macos-${{ matrix.arch }}${SUFFIX}"
           mkdir -p output
@@ -253,8 +281,26 @@ jobs:
             ICNS_PATH="$APP_DIR/Contents/Resources/AppIcon.icns"
           fi
 
-          # Ad-hoc sign the app bundle
-          codesign --force --deep --sign - "$APP_DIR"
+          # Decode the App Store Connect API key for notarytool
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
+          echo "$AC_API_KEY_P8" | base64 --decode > "$API_KEY_PATH"
+
+          # Sign with Developer ID + hardened runtime (inner binary first, then bundle)
+          codesign --force --options runtime --timestamp \
+            --sign "$MACOS_SIGN_IDENTITY" "$APP_DIR/Contents/MacOS/ultralog"
+          codesign --force --options runtime --timestamp \
+            --sign "$MACOS_SIGN_IDENTITY" "$APP_DIR"
+          codesign --verify --strict --verbose=2 "$APP_DIR"
+
+          # Notarize the app, then staple the ticket so it opens offline
+          ditto -c -k --keepParent "$APP_DIR" "$RUNNER_TEMP/app.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
+            --key "$API_KEY_PATH" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$APP_DIR"
+          rm -f "$RUNNER_TEMP/app.zip"
 
           # Create DMG with volume icon if available
           if [ -n "$ICNS_PATH" ]; then
@@ -283,6 +329,17 @@ jobs:
               "$APP_DIR" || \
               hdiutil create -volname "${DMG_VOLNAME}" -srcfolder "$APP_DIR" -ov -format UDZO "output/${ASSET_NAME}.dmg"
           fi
+
+          # Sign, notarize, and staple the DMG so the download itself is trusted
+          codesign --force --timestamp --sign "$MACOS_SIGN_IDENTITY" "output/${ASSET_NAME}.dmg"
+          xcrun notarytool submit "output/${ASSET_NAME}.dmg" \
+            --key "$API_KEY_PATH" \
+            --key-id "$AC_API_KEY_ID" \
+            --issuer "$AC_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "output/${ASSET_NAME}.dmg"
+          xcrun stapler validate "output/${ASSET_NAME}.dmg"
+          rm -f "$API_KEY_PATH"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -362,7 +419,7 @@ jobs:
                - **Intel Mac**: `ultralog-macos-intel-beta.dmg`
                - **Apple Silicon (M1/M2/M3/M4)**: `ultralog-macos-arm64-beta.dmg`
             2. Open the DMG and drag UltraLog to your Applications folder
-            3. On first run, right-click the app and select "Open" to bypass Gatekeeper
+            3. Launch UltraLog from Applications. Beta builds are signed and notarized by Apple, so they open without a Gatekeeper warning.
 
             ### Windows
             1. Download `ultralog-windows-beta.zip`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1281,7 +1281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1746,9 +1746,9 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "half"
@@ -2654,7 +2654,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3918,7 +3918,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3947,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4358,7 +4358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4530,9 +4530,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -4958,7 +4958,7 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ultralog"
-version = "2.10.0"
+version = "2.10.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5646,7 +5646,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ultralog"
-version = "2.10.0"
+version = "2.10.1"
 edition = "2021"
 description = "A high-performance ECU log viewer written in Rust"
 authors = ["Cole Gentry"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A high-performance, cross-platform ECU log viewer written in Rust.
 
 ![CI](https://github.com/ClassicMiniDIY/UltraLog/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-AGPL--3.0-blue.svg)
-![Version](https://img.shields.io/badge/version-2.10.0-green.svg)
+![Version](https://img.shields.io/badge/version-2.10.1-green.svg)
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,8 +112,8 @@
         "applicationCategory": "UtilitiesApplication",
         "applicationSubCategory": "Automotive Software",
         "operatingSystem": ["Windows 10", "Windows 11", "macOS", "Linux"],
-        "softwareVersion": "2.5.0",
-        "releaseNotes": "https://github.com/ClassicMiniDIY/UltraLog/releases/tag/v2.5.0",
+        "softwareVersion": "2.10.1",
+        "releaseNotes": "https://github.com/ClassicMiniDIY/UltraLog/releases/tag/v2.10.1",
         "downloadUrl": "https://github.com/ClassicMiniDIY/UltraLog/releases/latest",
         "installUrl": "https://github.com/ClassicMiniDIY/UltraLog/releases/latest",
         "screenshot": [
@@ -1427,7 +1427,7 @@
                 <div class="hero-badges">
                     <span class="version-badge">
                         <span class="new-tag">New</span>
-                        v2.10.0
+                        v2.10.1
                     </span>
                     <a href="https://github.com/ClassicMiniDIY/UltraLog" class="opensource-badge" target="_blank" rel="noopener noreferrer">
                         <i class="fa-brands fa-github" aria-hidden="true"></i> Open Source


### PR DESCRIPTION
## Why

Users on macOS 15+ get *"UltraLog.app can't be opened because Apple cannot check it for malicious software"* and the right-click → Open bypass no longer works on Sequoia, generating a steady stream of bug reports. Root cause: the release workflow only **ad-hoc signed** the bundle (`codesign --sign -`) and never notarized it.

## What changed

### macOS code signing + notarization (`release.yml`)
- Import the Developer ID cert into a temporary keychain on the runner.
- Sign the binary and `.app` with a real **Developer ID Application** identity under **hardened runtime** (`--options runtime --timestamp`), replacing ad-hoc signing.
- Notarize via `notarytool --wait` and **staple** both the `.app` (before DMG build) and the `.dmg`, so installs open with zero warnings — even offline.
- Updated install instructions in `RELEASE_TEMPLATE.md` and the beta release body (removed the now-defunct "right-click → Open" advice).

Requires these repo secrets (already configured): `MACOS_CERT_P12`, `MACOS_CERT_PASSWORD`, `MACOS_SIGN_IDENTITY`, `MACOS_KEYCHAIN_PASSWORD`, `AC_API_KEY_ID`, `AC_API_ISSUER_ID`, `AC_API_KEY_P8`.

### Version bump to v2.10.1
- `Cargo.toml`, `Cargo.lock`, README badge, landing page badge fallback.
- Also corrected the schema.org `softwareVersion` / `releaseNotes` in `docs/index.html`, which were stale at 2.5.0.

### Dependency updates (incorporates #69)
- `tar` 0.4.44 → 0.4.45
- `grid` 1.0.0 → 1.0.1
- `rustls-webpki` 0.103.9 → 0.103.13 (security advisory fixes)

## Testing

`cargo check` passes; `cargo fmt --check` clean (pre-commit hook). Notarization path should be validated by cutting a `-beta` tag (routes to the prerelease job) before the stable `v2.10.1` tag — watch for `find-identity` listing the cert and `notarytool` returning `status: Accepted`.

Closes #69